### PR TITLE
Removed unusued deps `dart_code_metrics` deps and update deps `intl`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,7 @@ environment:
 
 dependencies:
   characters: ^1.3.0
-  dart_code_metrics: ^5.6.0
-  intl: ^0.18.0
+  intl: ^0.18.1
 
 dev_dependencies:
   lints: ^2.0.1


### PR DESCRIPTION
I have removed the 'dart_code_metrics' dependency from the project as it is no longer used and has become an unmaintained package (see [this](https://pub.dev/documentation/dart_code_metrics/latest/)) . This removal was necessary due to conflicts it was causing in my projects. Additionally, I have updated the 'intl' package to ensure it remains up-to-date.

Please can you take into consideration this PR.